### PR TITLE
document-link title may be wrapped in <narrative>

### DIFF
--- a/iatidq/inforesult_orgtests.py
+++ b/iatidq/inforesult_orgtests.py
@@ -197,9 +197,10 @@ def country_strategy_papers(doc):
         name = getCountryName(code, name, countrycodelist)
         for strategy_paper in strategy_papers:
             if name is not None:
-                title = strategy_paper.find('title').text.upper()
-                name = name.upper()
-                if re.compile("(.*)"+name+"(.*)").match(title):
+                title = strategy_paper.find('title')
+                if not title.text:
+                    title = title.find('narrative')
+                if re.search(name, title.text, flags=re.IGNORECASE):
                     try:
                         countries.pop(code)
                     except Exception:


### PR DESCRIPTION
Refs #453.

I don’t think this is quite correct yet. According to the schema, `<title>` can have several `<narrative>`s, so I guess we should find and check them all.